### PR TITLE
use urlparse.urljoin to join url paths together

### DIFF
--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -97,7 +97,7 @@ class TestTransmissionPrivateSend(unittest.TestCase):
             ev = FakeEvent()
             ev.writekey = "writeme"
             ev.dataset = "datame"
-            ev.api_host = "http://urlme"
+            ev.api_host = "http://urlme/"
             ev.metadata = "metame"
             ev.sample_rate = 3
             m.post("http://urlme/1/events/datame", text="", status_code=200)

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -1,6 +1,7 @@
 '''Transmission handles colleting and sending individual events to Honeycomb'''
 
 from six.moves import queue
+from urlparse import urljoin
 import threading
 import requests
 import statsd
@@ -68,7 +69,7 @@ class Transmission():
         '''_send should only be called from sender and sends an individual
             event to Honeycomb'''
         start = get_now()
-        url = ev.api_host + "/1/events/" + ev.dataset
+        url = urljoin(urljoin(ev.api_host, "/1/events/"), ev.dataset)
         req = requests.Request('POST', url, data=str(ev))
         req.headers.update({
             "X-Event-Time": ev.created_at.isoformat("T"),


### PR DESCRIPTION
python version of the honeycombio/libhoney-go#8 change.  use urlparse.urljoin so that trailing slashes in `api_host` aren't a problem.