### PR TITLE
changing libhoney.py to require utc times

### DIFF
--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -228,7 +228,7 @@ class Event(object):
         [self._fields.add_dynamic_field(fn) for fn in dyn_fields]
         self._fields += fields
         # fill in other info
-        self.created_at = datetime.datetime.now()
+        self.created_at = datetime.datetime.utcnow()
         self.writekey = g_writekey
         self.dataset = g_dataset
         self.api_host = g_api_host

--- a/libhoney/test_libhoney.py
+++ b/libhoney/test_libhoney.py
@@ -197,6 +197,8 @@ class TestEvent(unittest.TestCase):
                 self.time = time
             def now(self):
                 return self.time
+            def utcnow(self):
+                return self.time
         fakeStart = datetime.datetime(2016, 1, 2, 3, 4, 5, 6)
         fakeEnd = fakeStart + datetime.timedelta(milliseconds=5)
         fd = fakeDate()

--- a/libhoney/version.py
+++ b/libhoney/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.3"
+VERSION = "1.0.4"


### PR DESCRIPTION
Since datetime objects are naive by default, always use the UTC time when timestamping events and default to sending UTC timestamps.  If you override the event's timestamp with an aware datetime object, `isoformat()` should append the correct timezone.  If you override the event's timestamp with a naive datetime object, the datetime object must represent UTC.