### PR TITLE
[example] Make sure libhoney.close() gets called for SIGINT/SIGTERM

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,6 +1,7 @@
 '''This example shows how to use some of the features of libhoney in python'''
 
 import libhoney
+import signal
 import threading
 
 writekey = "abcabc123123defdef456456"
@@ -46,11 +47,19 @@ def read_responses(resp_queue):
         print status
 
 
-def main():
+def graceful_shutdown(signum, frame):
+    libhoney.close()
+
+
+if __name__ == "__main__":
     libhoney.init(writekey=writekey, dataset=dataset, max_concurrent_batches=1)
     resps = libhoney.responses()
     t = threading.Thread(target=read_responses, args=(resps,))
     t.start()
+
+    # shut down gracefully
+    signal.signal(signal.SIGINT, graceful_shutdown)
+    signal.signal(signal.SIGTERM, graceful_shutdown)
 
     # attach fields to top-level instance
     libhoney.add_field("version", "3.4.5")
@@ -63,8 +72,4 @@ def main():
 
     # sends an event with "version", "num_threads", and "status" fields
     libhoney.send_now({"status": "ending run"})
-    libhoney.close()
-
-
-if __name__ == "__main__":
-    main()
+    graceful_shutdown(None, None)


### PR DESCRIPTION
Unfortunate experience if you try to Ctrl-C out of the example.py and it hangs forever.