### PR TITLE
Make `libhoney.close()` a noop if uninitialized

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Chris Toshok
 Christine Yen
 Ian Wilkes
 Steve Huff
+JJ Fliegelman

--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -106,7 +106,11 @@ def send_now(data):
 def close():
     '''wait for in-flight events to be transmitted then shut down cleanly'''
     global _xmit
-    _xmit.close()
+
+    # if libhoney was never initialized, don't try to close it
+    if _xmit:
+        _xmit.close()
+
     # we should error on post-close sends
     _xmit = None
 

--- a/libhoney/test_libhoney.py
+++ b/libhoney/test_libhoney.py
@@ -48,6 +48,16 @@ class TestGlobalScope(unittest.TestCase):
         mock_xmit.close.assert_called_with()
         self.assertEqual(libhoney._xmit, None)
 
+    def test_close_noop_if_not_init(self):
+        """
+        libhoney.close() should noop if never initialized
+        """
+        try:
+            libhoney.close()
+        except AttributeError:
+            self.fail('libhoney threw an exception on '
+                           'an uninitialized close.')
+
     def test_add_field(self):
         ed = {"whomp": True}
         libhoney.add_field("whomp", True)


### PR DESCRIPTION
I observed in my Django application that `libhoney` was causing the whole application to hang on Django management commands.  The reason was that `libhoney.init()` was called but `libhoney.close()` never did, and if `.close()` isn't called, the application will hang forever waiting for the threads.

To solve this, you could just call `libhoney.close()` always at the end of any management command wrapper, but if uninitialized it'll throw an `AttributeError`.  This PR makes `libhoney.close()` a noop if `libhoney` is uninitialized so calling `.close()` will always be safe.

Going forward, I'd recommend either or both of making the package listen for exit signals to shut down the background threads automatically without having to call `.close()`, or at the very least also offering a context manager interface so a user could do something like the following:

```python
# entrypoint wrapper code
with libhoney.init(...):
   # rest of application goes here
```

And `libhoney` would automatically call `.close()` on `__exit__()`.  