### PR TITLE
Handle signals inside libhoney, not just the example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,6 @@
 '''This example shows how to use some of the features of libhoney in python'''
 
 import libhoney
-import signal
 import threading
 
 writekey = "abcabc123123defdef456456"
@@ -47,19 +46,11 @@ def read_responses(resp_queue):
         print status
 
 
-def graceful_shutdown(signum, frame):
-    libhoney.close()
-
-
 if __name__ == "__main__":
     libhoney.init(writekey=writekey, dataset=dataset, max_concurrent_batches=1)
     resps = libhoney.responses()
     t = threading.Thread(target=read_responses, args=(resps,))
     t.start()
-
-    # shut down gracefully
-    signal.signal(signal.SIGINT, graceful_shutdown)
-    signal.signal(signal.SIGTERM, graceful_shutdown)
 
     # attach fields to top-level instance
     libhoney.add_field("version", "3.4.5")

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -4,6 +4,7 @@ from six.moves import queue
 from six.moves.urllib.parse import urljoin
 import threading
 import requests
+import signal
 import statsd
 import datetime
 
@@ -33,6 +34,9 @@ class Transmission():
             t = threading.Thread(target=self._sender)
             t.start()
             self.threads.append(t)
+        # shut down gracefully
+        signal.signal(signal.SIGINT, self.caught_signal)
+        signal.signal(signal.SIGTERM, self.caught_signal)
 
     def send(self, ev):
         '''send accepts an event and queues it to be sent'''
@@ -109,6 +113,9 @@ class Transmission():
             t.join()
         # signal to the responses queue that nothing more is coming.
         self.responses.put(None)
+
+    def caught_signal(self, signum, frame):
+        self.close()
 
     def get_response_queue(self):
         ''' return the responses queue on to which will be sent the response


### PR DESCRIPTION
Turns out the sentiment was correct on both sides in https://github.com/honeycombio/libhoney-py/pull/11 (cc @emfree) but the wrong conclusion was reached -- and an unfortunate soul ran into it via a perfectly reasonable situation (described in https://github.com/honeycombio/libhoney-py/pull/12, which is also 👍).

This should do slightly more of the right thing (aka, not just fixing the example.py).