### PR TITLE
catch queue full exceptions on the response queue in addition to the sending queue

### DIFF
--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -107,14 +107,15 @@ class Transmission():
 
     def close(self):
         '''call close to send all in-flight requests and shut down the
-           senders nicely'''
+            senders nicely. Times out after max 20 seconds per sending thread
+            plus 10 seconds for the response queue'''
         for i in range(self.max_concurrent_batches):
             try:
                 self.pending.put(None, true, 10)
             except queue.Full:
                 pass
         for t in self.threads:
-            t.join()
+            t.join(10)
         # signal to the responses queue that nothing more is coming.
         try:
             self.responses.put(None, true, 10)


### PR DESCRIPTION
When calling `send` on an event, if honeycomb is backed up, it should not affect the running application at all. It is the case that (unless `block_on_send` is set) sending will drop events when the sending queue overflows instead of backing up the calling application.  However, if the response queue filled up, it would throw an exception and cause unexpected mayhem.  That's not cool. 

This change protects the response queue with the same enthusiasm that currently protects the sending queue to make sure that if libhoney can't keep up sending traffic to Honeycomb, it will prefer to drop events and protect the app than raise that error.