### PR TITLE
Automatic `close()` on exit, don't hang on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ libhoney.send_now({
   "hostname": "appserver15",
   "payload_length": 27
 })
-
-# Call close to flush any pending calls to Honeycomb
-libhoney.close()
 ```
 
 You can find a more complete example demonstrating usage in [`example.py`](example.py)

--- a/example.py
+++ b/example.py
@@ -39,6 +39,7 @@ def read_responses(resp_queue):
     '''read responses from the libhoney queue, print them out.'''
     while True:
         resp = resp_queue.get()
+        # libhoney will enqueue a None value after we call libhoney.close()
         if resp is None:
             break
         status = "sending event with metadata {} took {}ms and got response code {} with message \"{}\"".format(
@@ -47,29 +48,32 @@ def read_responses(resp_queue):
         print status
 
 
-def graceful_shutdown(signum, frame):
-    libhoney.close()
-
-
 if __name__ == "__main__":
     libhoney.init(writekey=writekey, dataset=dataset, max_concurrent_batches=1)
     resps = libhoney.responses()
     t = threading.Thread(target=read_responses, args=(resps,))
+
+    # Mark this thread as a daemon so we don't wait for this thread to exit
+    # before shutting down.  Alternatively, to be sure you read all the
+    # responses before exiting, omit this line and explicitly call
+    # libhoney.close() at the end of the script.
+    t.daemon = True
+
     t.start()
 
-    # shut down gracefully
-    signal.signal(signal.SIGINT, graceful_shutdown)
-    signal.signal(signal.SIGTERM, graceful_shutdown)
-
-    # attach fields to top-level instance
+    # Attach fields to top-level instance
     libhoney.add_field("version", "3.4.5")
     libhoney.add_dynamic_field(num_threads)
 
-    # sends an event with "version", "num_threads", and "status" fields
+    # Sends an event with "version", "num_threads", and "status" fields
     libhoney.send_now({"status": "starting run"})
     run_fact(1, 2, libhoney.Builder({"range": "low"}))
     run_fact(31, 32, libhoney.Builder({"range": "high"}))
 
-    # sends an event with "version", "num_threads", and "status" fields
+    # Sends an event with "version", "num_threads", and "status" fields
     libhoney.send_now({"status": "ending run"})
-    graceful_shutdown(None, None)
+
+    # Optionally tell libhoney there are no more events coming.  This ensures
+    # the read_responses thread will terminate.
+
+    #libhoney.close()

--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -5,7 +5,7 @@ Basic usage:
 * initialize libhoney with your Honeycomb writekey and dataset name
 * create an event object and populate it with fields
 * send the event object
-* close libhoney when your program is finished
+* libhoney will close automatically when your program is finished
 
 Sending on a closed or uninitialized libhoney will throw a libhoney.SendError
 exception.
@@ -105,7 +105,10 @@ def send_now(data):
 
 
 def close():
-    '''wait for in-flight events to be transmitted then shut down cleanly'''
+    '''Wait for in-flight events to be transmitted then shut down cleanly.
+       Optional (will be called automatically at exit) unless your
+       application is consuming from the responses queue and needs to know
+       when all responses have been received.'''
     global _xmit
 
     # if libhoney was never initialized, don't try to close it

--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -12,6 +12,7 @@ exception.
 
 You can find an example demonstrating usage in example.py'''
 
+import atexit
 import datetime
 from contextlib import contextmanager
 import json
@@ -113,6 +114,9 @@ def close():
 
     # we should error on post-close sends
     _xmit = None
+
+
+atexit.register(close) # safe because it's a no-op unless init() was called
 
 
 class FieldHolder:

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -31,6 +31,7 @@ class Transmission():
         self.threads = []
         for i in range(self.max_concurrent_batches):
             t = threading.Thread(target=self._sender)
+            t.daemon = True
             t.start()
             self.threads.append(t)
 


### PR DESCRIPTION
As reported by #20, libhoney-py <= 1.0.11 causes Python to hang on exit, not responding to Ctrl-C, if the script didn't call `libhoney.close()` before exiting. This is because Python is waiting for our sender threads to exit, which they never will because all of the threads that might have told them to exit have already exited.

This makes our sender threads daemon threads (per @emfree's [suggestion](https://github.com/honeycombio/libhoney-py/pull/11#pullrequestreview-22364572) in #11) to fix that immediate problem.

This also sidesteps all the problems with signal handling (see #11 and the later-reverted #13), since we no longer interfere at all with program lifecycle (unless `close()` itself were to hang due to a bug). Signal handling is the app's responsibility and not something a library should touch.

To ensure we still send all queued events before exiting, this adds an [atexit](https://docs.python.org/2/library/atexit.html) hook to call `libhoney.close()` automatically on exit. This will still block the script until `close()` has completed (ensuring we drain the queue, send all the events, etc).

I've also updated the docstrings, README and `example.py` to stop recommending an explicit call to `libhoney.close()`, since most apps will no longer need to care about it. (However this should be backwards compatible with apps that already call it, since #12 made repeat calls to `close()` a no-op.)

The one exception is an app (such as `example.py` prior to this change) which has a non-daemon thread consuming the `responses` queue. In that case there is a deadlock: the atexit hook won't fire (and so the automatic `close()` won't happen) until the responses thread exits, but that won't happen until libhoney enqueues a `None` onto the responses queue, which won't happen because `close()` didn't get called. In that case - where the app really cares about receiving every last response - the app still needs to explicitly call `libhoney.close()` to break the deadlock.

I've modified `example.py` to instead use a daemon thread to consume the responses queue, since I think that's more representative of likely usage: consuming responses is informational but not worth holding up program exit.