### PR TITLE
Defer import-time socket instantiation

### DIFF
--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -18,7 +18,6 @@ from contextlib import contextmanager
 import json
 from libhoney import transmission
 import inspect
-import statsd
 import random
 from six.moves import queue
 from libhoney.version import VERSION
@@ -34,8 +33,6 @@ g_responses = queue.Queue(maxsize=1)
 g_block_on_response = False
 
 transmission.VERSION = VERSION
-
-sd = statsd.StatsClient(prefix="libhoney")
 
 random.seed()
 
@@ -289,7 +286,6 @@ class Event(object):
             raise SendError(
                 "Tried to send on a closed or uninitialized libhoney")
         if _should_drop(self.sample_rate):
-            sd.incr("sampled")
             _send_dropped_response(self)
             return
         self.send_presampled()


### PR DESCRIPTION
Per user request, avoid creating sockets at import time. In order to do
that, make the global statsd client an instance variable of
`Transmission`. This means that instantiation happens when you call
`libhoney.init`, not at import time.

Test plan: monkeypatch `socket.socket`, check that `import libhoney`
does not raise.