### PR TITLE
Fix event timestamps in transmission

### DIFF
--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -119,6 +119,13 @@ class TestTransmissionPrivateSend(unittest.TestCase):
                 resp_count += 1
             assert resp_count == 300
 
+            for req in m.request_history:
+                body = req.json()
+                for event in body:
+                    assert event["time"] == "2013-01-01T11:11:11Z"
+                    assert event["samplerate"] == 3
+
+
     def test_grouping(self):
         with requests_mock.Mocker() as m:
             m.post("http://urlme/1/batch/dataset",

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -116,7 +116,7 @@ class Transmission():
                 if ev.created_at.tzinfo is None:
                     event_time += "Z"
                 payload.append({
-                    "timestamp": event_time,
+                    "time": event_time,
                     "samplerate": ev.sample_rate,
                     "data": ev.fields()})
             resp = self.session.post(


### PR DESCRIPTION
The batch API accepts payloads of the form

```
{
    "time": "<time>",
    "samplerate": 22,
    "data": {...}
}
```

not

```
{
    "timestamp": "<time>",
    "samplerate": 22,
    "data": {...}
}
```

Doh!

Test plan: run test script and verify results in UI; new unit test