### PR TITLE
Support older versions of requests package

### DIFF
--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -2,6 +2,7 @@
 
 from six.moves import queue
 from six.moves.urllib.parse import urljoin
+import json
 import threading
 import requests
 import statsd
@@ -121,8 +122,8 @@ class Transmission():
                     "data": ev.fields()})
             resp = self.session.post(
                 url,
-                headers={"X-Honeycomb-Team": destination.writekey},
-                json=payload)
+                headers={"X-Honeycomb-Team": destination.writekey, "Content-Type": "application/json"},
+                data=json.dumps(payload))
             status_code = resp.status_code
             resp.raise_for_status()
             statuses = [d["status"] for d in resp.json()]


### PR DESCRIPTION
Support for the `json` parameter was added to requests version 2.4.2,
published in 2014. (https://github.com/requests/requests/blob/master/HISTORY.rst#242-2014-10-05)
We could require a newer `requests` version in setup.py, but we might as
well just be compatible with the older versions that still seem to be out in the
wild.

Fixes #30