### PR TITLE
Add transmission implementation for tornado

### DIFF
--- a/example_tornado.py
+++ b/example_tornado.py
@@ -31,7 +31,7 @@ def event_routine():
 @gen.coroutine
 def main():
     libhoney.init(writekey="abcabc123123defdef456456", dataset="factorial.tornado",
-        xmit=TornadoTransmission())
+        transmission_impl=TornadoTransmission())
     ioloop.IOLoop.current().spawn_callback(event_routine)
 
     while True:

--- a/example_tornado.py
+++ b/example_tornado.py
@@ -1,0 +1,43 @@
+from tornado import ioloop, gen
+import libhoney
+from libhoney.transmission import TornadoTransmission
+
+def factorial(n):
+    if n < 0:
+        return -1 * factorial(abs(n))
+    if n == 0:
+        return 1
+    return n * factorial(n - 1)
+
+def run_fact(low, high, libh_builder):
+    for i in range(low, high):
+        ev = libh_builder.new_event()
+        ev.metadata = {"fn": "run_fact", "i": i}
+        with ev.timer("fact_timer"):
+            res = factorial(10 + i)
+            ev.add_field("retval", res)
+        ev.send()
+        print("About to send event: %s" % ev)
+
+@gen.coroutine
+def event_routine():
+    event_counter = 1
+    while event_counter <= 100:
+        run_fact(1, event_counter, libhoney.Builder({"event_counter": event_counter}))
+
+        event_counter += 1
+        yield gen.sleep(0.1)
+
+@gen.coroutine
+def main():
+    libhoney.init(writekey="abcabc123123defdef456456", dataset="factorial.tornado",
+        xmit=TornadoTransmission())
+    ioloop.IOLoop.current().spawn_callback(event_routine)
+
+    while True:
+        r = yield libhoney.responses().get()
+        print("Got response: %s" % r)
+
+if __name__ == "__main__":
+    ioloop.IOLoop.current().run_sync(main)
+

--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -41,7 +41,7 @@ random.seed()
 def init(writekey="", dataset="", sample_rate=1,
          api_host="https://api.honeycomb.io", max_concurrent_batches=10,
          max_batch_size=100, send_frequency=0.25,
-         block_on_send=False, block_on_response=False):
+         block_on_send=False, block_on_response=False, xmit=None):
     '''Initialize libhoney and prepare it to send events to Honeycomb.
 
     Note that libhoney initialization initializes a number of threads to handle
@@ -63,6 +63,7 @@ def init(writekey="", dataset="", sample_rate=1,
             events until there's room in the queue
     - `block_on_response`: if true, block when the response queue fills. If
             false, drop response objects.
+    - `xmit`: if set, override the default transmission implementation (for example, TornadoTransmission)
 
     --------
 
@@ -84,8 +85,10 @@ def init(writekey="", dataset="", sample_rate=1,
     '''
     global _xmit, g_writekey, g_dataset, g_api_host, g_sample_rate, g_responses
     global g_block_on_response
-    _xmit = transmission.Transmission(max_concurrent_batches, block_on_send,
-                                      block_on_response)
+    _xmit = xmit
+    if xmit is None:
+        _xmit = transmission.Transmission(max_concurrent_batches, block_on_send,
+                                        block_on_response)
     _xmit.start()
     g_writekey = writekey
     g_dataset = dataset

--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -41,7 +41,7 @@ random.seed()
 def init(writekey="", dataset="", sample_rate=1,
          api_host="https://api.honeycomb.io", max_concurrent_batches=10,
          max_batch_size=100, send_frequency=0.25,
-         block_on_send=False, block_on_response=False, xmit=None):
+         block_on_send=False, block_on_response=False, transmission_impl=None):
     '''Initialize libhoney and prepare it to send events to Honeycomb.
 
     Note that libhoney initialization initializes a number of threads to handle
@@ -63,7 +63,7 @@ def init(writekey="", dataset="", sample_rate=1,
             events until there's room in the queue
     - `block_on_response`: if true, block when the response queue fills. If
             false, drop response objects.
-    - `xmit`: if set, override the default transmission implementation (for example, TornadoTransmission)
+    - `transmission_impl`: if set, override the default transmission implementation (for example, TornadoTransmission)
 
     --------
 
@@ -85,8 +85,8 @@ def init(writekey="", dataset="", sample_rate=1,
     '''
     global _xmit, g_writekey, g_dataset, g_api_host, g_sample_rate, g_responses
     global g_block_on_response
-    _xmit = xmit
-    if xmit is None:
+    _xmit = transmission_impl
+    if _xmit is None:
         _xmit = transmission.Transmission(max_concurrent_batches, block_on_send,
                                         block_on_response)
     _xmit.start()

--- a/libhoney/test_tornado.py
+++ b/libhoney/test_tornado.py
@@ -1,0 +1,77 @@
+'''Tests for libhoney/transmission.py'''
+
+import datetime
+import unittest
+
+import mock
+import six
+import tornado
+import transmission
+
+PATCH_NAMESPACE='transmission'
+if six.PY2:
+    PATCH_NAMESPACE='libhoney.transmission'
+
+
+class TestTornadoTransmissionInit(unittest.TestCase):
+    def test_defaults(self):
+        t = transmission.TornadoTransmission()
+        self.assertIsInstance(t.batch_sem, tornado.locks.Semaphore)
+        self.assertIsInstance(t.pending, tornado.queues.Queue)
+        self.assertIsInstance(t.responses, tornado.queues.Queue)
+        self.assertEqual(t.block_on_send, False)
+        self.assertEqual(t.block_on_response, False)
+
+    def test_args(self):
+        t = transmission.TornadoTransmission(max_concurrent_batches=4, block_on_send=True, block_on_response=True)
+        t.start()
+        self.assertEqual(t.block_on_send, True)
+        self.assertEqual(t.block_on_response, True)
+        t.close()
+
+
+class TestTornadoTransmissionSend(unittest.TestCase):
+    def test_send(self):
+        with mock.patch(PATCH_NAMESPACE+'.AsyncHTTPClient') as m_http,\
+                mock.patch('statsd.StatsClient') as m_statsd:
+            m_http.return_value = mock.Mock()
+            m_statsd.return_value = mock.Mock()
+            @tornado.gen.coroutine
+            def _test():
+                t = transmission.TornadoTransmission()
+                t.start()
+
+                ev = mock.Mock(metadata=None, writekey="abc123",
+                               dataset="blargh", api_host="https://example.com",
+                               sample_rate=1, created_at=datetime.datetime.now())
+                ev.fields.return_value = {"foo": "bar"}
+                t.send(ev)
+
+                # wait on the batch to be "sent"
+                # we can detect this when data has been inserted into the
+                # batch data dictionary
+                while not t.batch_data:
+                    yield tornado.gen.sleep(0.01)
+                t.close()
+
+            tornado.ioloop.IOLoop.current().run_sync(_test)
+            m_statsd.return_value.incr.assert_any_call("messages_queued")
+            self.assertTrue(m_http.return_value.fetch.called)
+
+
+class TestTornadoTransmissionQueueOverflow(unittest.TestCase):
+     def test_send(self):
+         with mock.patch('statsd.StatsClient') as m_statsd:
+            m_statsd.return_value = mock.Mock()
+
+            t = transmission.TornadoTransmission()
+            t.pending = tornado.queues.Queue(maxsize=2)
+            t.responses = tornado.queues.Queue(maxsize=1)
+            # we don't call start on transmission here, which will cause
+            # the queue to pile up
+
+            t.send(mock.Mock())
+            t.send(mock.Mock())
+            t.send(mock.Mock()) # should overflow sending and land on response
+            m_statsd.return_value.incr.assert_any_call("queue_overflow")
+            t.send(mock.Mock()) # shouldn't throw exception when response is full

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -244,6 +244,9 @@ if has_tornado:
                         pass
                 self.sd.incr("queue_overflow")
 
+        # We're using the older decorator/yield model for compatibility with
+        # Python versions before 3.5.
+        # See: http://www.tornadoweb.org/en/stable/guide/coroutines.html#python-3-5-async-and-await
         @gen.coroutine
         def _sender(self):
             '''_sender is the control loop that pulls events off the `self.pending`

--- a/libhoney/version.py
+++ b/libhoney/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.2.2"
+VERSION = "1.2.3"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(name='libhoney',
         'mock',
         'pbr',
         'requests-mock',
-        'bumpversion'
+        'bumpversion',
+        'tornado',
       ],
       test_suite='libhoney',
       zip_safe=False)


### PR DESCRIPTION
In its current form this is a POC. Some things that need to be figured out:

- where's the "correct" place to init honeycomb - is it safe to do before the event loop is started by the application?
- how should we structure `transmission.py` - throwing all of the implementations in one file might be messy
- add tests!
- what's the cleanest way to define a transmission that depends on libraries the caller may or may not have? The "import and catch ImportError" approach feels hacky, but I also do not want to make tornado a hard dependency for libhoney.
- oh yeah and: python2.7, how much do we care about it for this?