### PR TITLE
Add a tracing wrapper

### DIFF
--- a/example_tracing.py
+++ b/example_tracing.py
@@ -1,0 +1,22 @@
+import libhoney
+from libhoney import trace_call
+
+def fib(n):
+    if n == 0: return 0
+    elif n == 1: return 1
+    else: 
+        return trace_call(fib, n-1, trace_name="fib %d" % (n-1)) + \
+               trace_call(fib, n-2, trace_name="fib %d" % (n-2))
+
+def main():
+    trace_call(fib, 1, trace_name="fib 1", service_name="fabulous fibonacci")
+    trace_call(fib, 5, trace_name="fib 5", service_name="fabulous fibonacci")
+    trace_call(fib, 10, trace_name="fib 10", service_name="fabulous fibonacci")
+
+if __name__ == "__main__":
+    libhoney.init(writekey='abcdefghijklmnopqrstuvwxyz', dataset='fibonacci')
+    try:
+        trace_call(main)
+    except Exception as e:
+        print(e)
+    libhoney.close()

--- a/libhoney/trace.py
+++ b/libhoney/trace.py
@@ -1,0 +1,93 @@
+import datetime
+import hashlib
+import inspect
+import math
+import struct
+import uuid
+
+import libhoney
+
+MAX_INT32 = math.pow(2, 32) - 1
+
+class Tracer(object):
+    def __init__(self, sample_rate=1.0):
+        self.trace_ids = {}
+        self.span_ids = {}
+        self.sample_upper_bound = MAX_INT32 / sample_rate
+
+    def _get_parent_span(self, frame):
+        ''' determine if a frame up the stack has a span_id '''
+        # skip the current frame, and look for a previous frame with a span_id
+        frame = frame.f_back
+        
+        while frame:
+            if id(frame) in self.span_ids:
+                return frame
+            frame = frame.f_back
+
+        return None
+
+    def _should_sample(self, trace_id):
+        # compute a sha1
+        sha1 = hashlib.sha1()
+        sha1.update(trace_id.encode('utf-8'))
+        # convert last 4 digits to int
+        value, = struct.unpack('<I', sha1.digest()[-4:])
+        return value < self.sample_upper_bound
+
+    def trace_call(self, fn, *args, service_name="", trace_name="", trace_context=None, trace_id="", **kwargs):
+        current_frame = inspect.currentframe()
+        parent = self._get_parent_span(current_frame)
+
+        # we're the first span, generate trace ID AND span ID
+        if parent is None:
+            # if the trace ID has been passed in, do not generate a new one
+            if not trace_id:
+                trace_id = _new_id()
+            
+            self.trace_ids[id(current_frame)] = trace_id
+            self.span_ids[id(current_frame)] = _new_id()
+            parent_span_id = None
+        else:
+            self.trace_ids[id(current_frame)] = self.trace_ids[id(parent)]
+            self.span_ids[id(current_frame)] = _new_id()
+            parent_span_id = self.span_ids[id(parent)]
+
+        # once we know the trace ID of this frame, we can decide if we should
+        # sample it
+        should_sample = self._should_sample(self.trace_ids[id(current_frame)])
+
+        if should_sample:
+            time_start = datetime.datetime.now()
+            ev = libhoney.Event()
+
+        try:
+            ret = fn(*args, **kwargs)
+        finally:
+            if should_sample:
+                duration = datetime.datetime.now() - time_start
+                duration_ms = duration.total_seconds() * 1000.0
+
+                if not trace_name:
+                    trace_name = fn.__name__
+
+                if trace_context is None:
+                    trace_context = {}
+                trace_context["trace.trace_id"] = self.trace_ids[id(current_frame)]
+                trace_context["trace.span_id"] = self.span_ids[id(current_frame)]
+                trace_context["trace.parent_id"] = parent_span_id
+                trace_context["duration_ms"] = duration_ms
+                trace_context["name"] = trace_name
+                if service_name:
+                    trace_context["service_name"] = service_name
+                ev.add(trace_context)
+                ev.send_presampled()
+
+            # clean up our dicts when we exit the span
+            del self.span_ids[id(current_frame)]
+            del self.trace_ids[id(current_frame)]
+
+        return ret
+
+def _new_id():
+    return str(uuid.uuid4())


### PR DESCRIPTION
I'd like to make tracing as easy as using a wrapper or context manager. I think we can efficiently leverage the `inspect` lib in python to build the trace_id/parent_id/span_id hierarchy of events without having to thread a bunch of context down the call stack. With this approach, a consumer of the SDK can add tracing by just adding calls to the wrapper at arbitrary points in their code.

I also took a stab at deterministic sampling, but this may need some work. Also, this is written with the old global state model that gets changed in https://github.com/honeycombio/libhoney-py/pull/33 - will need to slightly refactor when that gets comitted.

Will write tests before this ever lands, but I wanted to get some feedback on the approach before spending anymore time on it.