### PR TITLE
Add a flush method to support Lambda use cases

### DIFF
--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -152,6 +152,16 @@ def send_now(data):
     ev.add(data)
     ev.send()
 
+def flush():
+    '''Closes and restarts the transmission, sending all events. Use this
+    if you want to perform a blocking send of all events in your
+    application.
+
+    Note: does not work with asynchronous Transmission implementations such
+    as TornadoTransmission.
+    '''
+    if state.G_CLIENT:
+        state.G_CLIENT.flush()
 
 def close():
     '''Wait for in-flight events to be transmitted then shut down cleanly.

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -173,6 +173,19 @@ class Client(object):
         # we should error on post-close sends
         self.xmit = None
 
+
+    def flush(self):
+        '''Closes and restarts the transmission, sending all events. Use this
+        if you want to perform a blocking send of all events in your
+        application.
+
+        Note: does not work with asynchronous Transmission implementations such
+        as TornadoTransmission.
+        '''
+        if self.xmit and isinstance(self.xmit, Transmission):
+            self.xmit.close()
+            self.xmit.start()
+
     def new_event(self, data={}):
         '''Return an Event, initialized to be sent with this client'''
         ev = Event(data=data, client=self)

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -162,3 +162,28 @@ class TestClient(unittest.TestCase):
         mock_xmit = mock.Mock()
         with client.Client(transmission_impl=mock_xmit) as c:
             self.assertEqual(c.xmit, mock_xmit)
+
+class TestClientFlush(unittest.TestCase):
+    ''' separate test class because we don't want to mock transmission'''
+    def test_flush(self):
+        mock_xmit = mock.Mock(spec=libhoney.transmission.Transmission)
+        with client.Client(transmission_impl=mock_xmit) as c:
+            # start gets called when the class is initialized
+            mock_xmit.start.assert_called_once_with()
+            mock_xmit.reset_mock()
+            c.flush()
+
+            mock_xmit.close.assert_called_once_with()
+            mock_xmit.start.assert_called_once_with()
+
+        mock_xmit = mock.Mock(spec=libhoney.transmission.TornadoTransmission)
+        with client.Client(transmission_impl=mock_xmit) as c:
+            # start gets called when the class is initialized
+            mock_xmit.start.assert_called_once_with()
+            mock_xmit.reset_mock()
+            c.flush()
+
+            # we don't call close/start on TornadoTransmission because we can't
+            # force a flush in an async environment.
+            mock_xmit.close.assert_not_called()
+            mock_xmit.start.assert_not_called()


### PR DESCRIPTION
All the context is here: https://github.com/honeycombio/libhoney-go/pull/26

^ this, but for python.