### PR TITLE
[transmission] Add a FileTransmission for debugging/serverless support

### DIFF
--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -430,7 +430,7 @@ class FileTransmission():
     def flush(self):
         '''Exists to be consistent with the Transmission API, but does nothing
         '''
-        pass
+        self._output.flush()
 
     def get_response_queue(self):
         '''Not implemented in FileTransmission - you should not attempt to


### PR DESCRIPTION
Instrumenting Lambda apps in the long run will involve some way of getting events into honeycomb without adding additional latency to each function invocation. Right now, to reliably send events, one must call `flush` before the function exits, or risk some events not being sent due to the way Lambda containers freeze after the function returns. Flush is effective, but inefficient, especially for latency-sensitive applications.

Writing to the logs in Lambda is non-blocking, and when combined with a Cloudwatch Logs Subscription Filter, logs can be fed to another Lambda for asynchronous processing.

This diff adds a FileTransmission implementation, allowing event data to be sent to a python file object (defaults to stderr). The idea is that this event data could be slurped up by a single Lambda listening to multiple Cloudwatch Log groups, and then sent efficiently to Honeycomb. Also useful for debugging in general.