### PR TITLE
Added error message to responses print statement

### DIFF
--- a/example.py
+++ b/example.py
@@ -42,9 +42,9 @@ def read_responses(resp_queue):
         # libhoney will enqueue a None value after we call libhoney.close()
         if resp is None:
             break
-        status = "sending event with metadata {} took {}ms and got response code {} with message \"{}\"".format(
+        status = "sending event with metadata {} took {}ms and got response code {} with message \"{}\" and error message \"{}\"".format(
             resp["metadata"], resp["duration"], resp["status_code"],
-            resp["body"].rstrip())
+            resp["body"].rstrip(), resp["error"])
         print(status)
 
 


### PR DESCRIPTION
I added the error portion of the response object to provide more information about problems. If the json is non-serializable, you need the error portion to determine what went wrong. 