### PR TITLE
Add a default json encoding handler

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.6.2
+current_version = 1.7.0
 
 [bumpversion:file:libhoney/version.py]
 

--- a/libhoney/fields.py
+++ b/libhoney/fields.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from libhoney.internal import json_default_handler
 
 class FieldHolder:
     '''A FieldHolder is the generalized class that stores fields and dynamic
@@ -46,4 +47,4 @@ class FieldHolder:
 
     def __str__(self):
         '''returns a JSON blob of the fields in this holder'''
-        return json.dumps(self._data)
+        return json.dumps(self._data, default=json_default_handler)

--- a/libhoney/internal.py
+++ b/libhoney/internal.py
@@ -1,0 +1,7 @@
+def json_default_handler(obj):
+    ''' this function handles values that the json encoder does not understand
+    by attempting to call the object's __str__ method. '''
+    try:
+        return str(obj)
+    except Exception:
+        return 'libhoney was unable to encode value'

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -2,7 +2,6 @@
 
 from six.moves import queue
 from six.moves.urllib.parse import urljoin
-import datetime
 import json
 import threading
 import requests

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -2,6 +2,7 @@
 
 from six.moves import queue
 from six.moves.urllib.parse import urljoin
+import datetime
 import json
 import threading
 import requests
@@ -11,6 +12,7 @@ import time
 import collections
 import concurrent.futures
 from libhoney.version import VERSION
+from libhoney.internal import json_default_handler
 
 try:
     from tornado import ioloop, gen
@@ -156,7 +158,7 @@ class Transmission():
             resp = self.session.post(
                 url,
                 headers={"X-Honeycomb-Team": destination.writekey, "Content-Type": "application/json"},
-                data=json.dumps(payload),
+                data=json.dumps(payload, default=json_default_handler),
                 timeout=10.0,
             )
             status_code = resp.status_code
@@ -339,7 +341,7 @@ if has_tornado:
                         "X-Honeycomb-Team": destination.writekey,
                         "Content-Type": "application/json",
                     },
-                    body=json.dumps(payload),
+                    body=json.dumps(payload, default=json_default_handler),
                 )
                 self.http_client.fetch(req, self._response_callback)
                 # store the events that were sent so we can process responses later
@@ -443,7 +445,7 @@ class FileTransmission():
             "user_agent": self._user_agent,
             "data": ev.fields(),
         }
-        self._output.write(json.dumps(payload) + "\n")
+        self._output.write(json.dumps(payload, default=json_default_handler) + "\n")
 
     def close(self):
         '''Exists to be consistent with the Transmission API, but does nothing

--- a/libhoney/version.py
+++ b/libhoney/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.6.2"
+VERSION = "1.7.0"


### PR DESCRIPTION
Addresses https://github.com/honeycombio/beeline-python/issues/58

    The default json encoder does not understand how to handle certain types, such as datetime. Rather than fail to send the event, we can attempt to call the __str__ method on whatever objects the default encoder does not recognize.