### PR TITLE
Changes default send_frequency in TornadoTransmission from float to timedelta

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ Christine Yen
 Ian Wilkes
 Steve Huff
 JJ Fliegelman
+Ashwini Balnaves

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -1,4 +1,5 @@
 '''Transmission handles colleting and sending individual events to Honeycomb'''
+from datetime import timedelta
 
 from six.moves import queue
 from six.moves.urllib.parse import urljoin
@@ -220,7 +221,7 @@ if has_tornado:
 
     class TornadoTransmission():
         def __init__(self, max_concurrent_batches=10, block_on_send=False,
-                    block_on_response=False, max_batch_size=100, send_frequency=0.25,
+                    block_on_response=False, max_batch_size=100, send_frequency=timedelta(seconds=0.25),
                     user_agent_addition=''):
             if not has_tornado:
                 raise ImportError('TornadoTransmission requires tornado, but it was not found.')
@@ -296,7 +297,7 @@ if has_tornado:
                         return
                     events.append(ev)
                     if (len(events) > self.max_batch_size or
-                        time.time() - last_flush > self.send_frequency):
+                        time.time() - last_flush > self.send_frequency.total_seconds()):
                         yield self._flush(events)
                         events = []
                 except TimeoutError:


### PR DESCRIPTION
The timeout argument for the get method on a tornado queue 
differs from that of the standard library's `queue.Queue.get`. 
That method interprets numeric values as relative timeouts; 
this one interprets them as absolute deadlines and requires
``timedelta`` objects for relative timeouts (consistent with other
timeouts in Tornado). We want to use a relative time, so that 
the _sender coroutine does not immediately time out and fail
to block asynchronously.