### PR TITLE
[transmission] enable gzip compression by default, prep 1.8.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.7.2
+current_version = 1.8.0
 
 [bumpversion:file:libhoney/version.py]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # libhoney Changelog
 
+## 1.8.0 2019-7-16 - Update recommended
+
+Improvements
+
+- Default Transmission implementation now compresses payloads by default (using gzip compression level 1). Compression offers significant savings in network egress at the cost of some CPU. Can be disabled by overriding `transmission_impl` when calling `libhoney.init()` and specifying `gzip_enabled=False`. See our official [docs](https://docs.honeycomb.io/getting-data-in/python/sdk/#customizing-event-transmission) for more information about overriding the default transmission.
+
 ## 1.7.2 2019-7-11
 
 Fixes

--- a/libhoney/version.py
+++ b/libhoney/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.7.2"
+VERSION = "1.8.0"


### PR DESCRIPTION
This doesn't add compression in the Tornado Transmission implementation, but that's a tiny fraction of our traffic currently. I'd like to understand the ramifications of using gzip in an async framework before adding it there (for example, does Tornado have its own gzip implementation?).