### PR TITLE
Use public ENV context in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,16 +169,19 @@ workflows:
   build_libhoney:
     jobs:
       - setup_trace:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test:
+          context: Honeycomb Secrets for Public Repos
           matrix:
             parameters:
               python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
@@ -188,13 +191,14 @@ workflows:
           requires:
             - setup_trace
       - build:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - test
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:
@@ -203,7 +207,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_pypi:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:


### PR DESCRIPTION
* currently secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* majority of other repos already use the shared context, looks like this was set up
a while back before the context was created
* secret values are unchanged from what's currently in the project env variables