### PR TITLE
Send events as flat JSON objects.

### DIFF
--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -272,7 +272,8 @@ class TestFileTransmissionSend(unittest.TestCase):
             expected_event_time += "Z"
 
         expected_payload = {
-            "data": {'abc': 1, 'xyz': 2},
+            "abc": 1,
+            "xyz": 2,
             "samplerate": 2.0,
             "dataset": "exciting-dataset!",
             "time": expected_event_time,
@@ -301,7 +302,9 @@ class TestFileTransmissionSend(unittest.TestCase):
             expected_event_time += "Z"
 
         expected_payload = {
-            "data": {'abc': 1, 'xyz': 2, 'dt': str(dt)},
+            "abc": 1,
+            "xyz": 2,
+            "dt": str(dt),
             "samplerate": 2.0,
             "dataset": "exciting-dataset!",
             "time": expected_event_time,

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -471,13 +471,14 @@ class FileTransmission():
         # if processed by another honeycomb agent (i.e. agentless integrations
         # for AWS), this data will get used to route the event to the right
         # location with appropriate metadata
-        payload = {
+        payload = {}
+        payload.update(ev.fields())
+        payload.update({
             "time": event_time,
             "samplerate": ev.sample_rate,
             "dataset": ev.dataset,
             "user_agent": self._user_agent,
-            "data": ev.fields(),
-        }
+        })
         self._output.write(json.dumps(
             payload, default=json_default_handler) + "\n")
 


### PR DESCRIPTION
When using the FileTransmission, events were being sent in as a "data" attribute in JSON object. This trips up agents that parse the JSON and send them to Honeycomb (e.g. the honeycomb lambda extension). This modifies the FileTransmission to just send the data as a flat object.

Some users have reported difficulty using the Python beeline and the lambda extension together, for this reason. I'm curious to know, however, if this change would break any other integrations. It's certainly backward-incompatible - there are certain to be users who rely on the current behavior, so it would require a major bump. 