### PR TITLE
Make transmission queue sizes configurable

### DIFF
--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -20,7 +20,9 @@ class TestTransmissionInit(unittest.TestCase):
         t = transmission.Transmission()
         self.assertEqual(t.max_concurrent_batches, 10)
         self.assertIsInstance(t.pending, queue.Queue)
+        self.assertEqual(t.pending.maxsize, 1000)
         self.assertIsInstance(t.responses, queue.Queue)
+        self.assertEqual(t.responses.maxsize, 2000)
         self.assertEqual(t.block_on_send, False)
         self.assertEqual(t.block_on_response, False)
 
@@ -134,9 +136,7 @@ class TestTransmissionSend(unittest.TestCase):
 
 class TestTransmissionQueueOverflow(unittest.TestCase):
     def test_send(self):
-        t = transmission.Transmission()
-        t.pending = queue.Queue(maxsize=2)
-        t.responses = queue.Queue(maxsize=1)
+        t = transmission.Transmission(max_pending=2, max_responses=1)
 
         t.send(FakeEvent())
         t.send(FakeEvent())

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -35,7 +35,7 @@ class Transmission():
     def __init__(self, max_concurrent_batches=10, block_on_send=False,
                  block_on_response=False, max_batch_size=100, send_frequency=0.25,
                  user_agent_addition='', debug=False, gzip_enabled=True, gzip_compression_level=1,
-                 proxies={}):
+                 proxies={}, max_pending=1000, max_responses=2000):
         self.max_concurrent_batches = max_concurrent_batches
         self.block_on_send = block_on_send
         self.block_on_response = block_on_response
@@ -57,9 +57,9 @@ class Transmission():
         self.session = session
 
         # libhoney adds events to the pending queue for us to send
-        self.pending = queue.Queue(maxsize=1000)
+        self.pending = queue.Queue(maxsize=max_pending)
         # we hand back responses from the API on the responses queue
-        self.responses = queue.Queue(maxsize=2000)
+        self.responses = queue.Queue(maxsize=max_responses)
 
         self._sending_thread = None
         self.sd = statsd.StatsClient(prefix="libhoney")
@@ -250,7 +250,7 @@ if has_tornado:
     class TornadoTransmission():
         def __init__(self, max_concurrent_batches=10, block_on_send=False,
                      block_on_response=False, max_batch_size=100, send_frequency=timedelta(seconds=0.25),
-                     user_agent_addition=''):
+                     user_agent_addition='', max_pending=1000, max_responses=2000):
             if not has_tornado:
                 raise ImportError(
                     'TornadoTransmission requires tornado, but it was not found.')
@@ -269,9 +269,9 @@ if has_tornado:
                 defaults=dict(user_agent=user_agent))
 
             # libhoney adds events to the pending queue for us to send
-            self.pending = Queue(maxsize=1000)
+            self.pending = Queue(maxsize=max_pending)
             # we hand back responses from the API on the responses queue
-            self.responses = Queue(maxsize=2000)
+            self.responses = Queue(maxsize=max_responses)
 
             self.batch_data = {}
             self.sd = statsd.StatsClient(prefix="libhoney")


### PR DESCRIPTION
Previously, the queue sizes were hard coded as 1,000 pending events and
2,000 responses. But if you app is overflowing the queue, you may want
to tweak these numbers. Other libhoneys let you do this, such as
https://github.com/honeycombio/libhoney-rb/blob/61514becd70117ad0fafadda350b144cda1d4b07/lib/libhoney/transmission.rb#L16

While you could manually assign something like `transmission.pending =
queue.Queue(maxsize=n)` (as the unit tests did previously), this
configuration option makes it a little friendlier. I added the keyword
arguments to the end of `__init__` to preserve compatibility with params
passed by order (instead of by name).