### PR TITLE
Drop use of long-deprecated `warn()` method

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Ben Hartshorne
 Charity Majors
 Chris Toshok
 Christine Yen
+David Cain
 Ian Wilkes
 Steve Huff
 JJ Fliegelman

--- a/libhoney/state.py
+++ b/libhoney/state.py
@@ -9,5 +9,5 @@ def warn_uninitialized():
     log = logging.getLogger(__name__)
     global WARNED_UNINITIALIZED
     if not WARNED_UNINITIALIZED:
-        log.warn("global libhoney method used before initialization")
+        log.warning("global libhoney method used before initialization")
         WARNED_UNINITIALIZED = True


### PR DESCRIPTION
This silences a `DeprecationWarning` but changes no functionality.

From Python docs:

> There is an obsolete method `warn` which is functionally identical to
> `warning`. As warn is deprecated, please do not use it - use `warning`
> instead.

https://docs.python.org/3/library/logging.html#logging.warning

This deprecation was added starting with Python 3.3.
All major versions of Python have `logging.warning`.