### PR TITLE
Remove API Reference broken link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 Python library for sending events to [Honeycomb](https://honeycomb.io), a service for debugging your software in production.
 
 - [Usage and Examples](https://docs.honeycomb.io/sdk/python/)
-- [API Reference](https://honeycombio.github.io/libhoney-py/)
 
 For tracing support and automatic instrumentation of Django, Flask, AWS Lambda, and other frameworks, check out our [Beeline for Python](https://github.com/honeycombio/beeline-python).
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- README contained a broken link for API Reference.

## Short description of the changes

- This has been removed, and a new issue will be opened for consideration to add a working API reference doc

