### PR TITLE
Fix tornado error handling

### DIFF
--- a/libhoney/test_tornado.py
+++ b/libhoney/test_tornado.py
@@ -1,5 +1,4 @@
 '''Tests for libhoney/transmission.py'''
-import asyncio
 import datetime
 import unittest
 
@@ -43,7 +42,7 @@ class TestTornadoTransmissionSend(unittest.TestCase):
     def test_send(self):
         with mock.patch('libhoney.transmission.AsyncHTTPClient.fetch') as fetch_mock,\
                 mock.patch('statsd.StatsClient') as m_statsd:
-            future = asyncio.Future()
+            future = tornado.concurrent.Future()
             future.set_result("OK")
             fetch_mock.return_value = future
             m_statsd.return_value = mock.Mock()
@@ -78,7 +77,7 @@ class TestTornadoTransmissionSendError(unittest.TestCase):
     def test_send(self):
         with mock.patch('libhoney.transmission.AsyncHTTPClient.fetch') as fetch_mock,\
                 mock.patch('statsd.StatsClient') as m_statsd:
-            future = asyncio.Future()
+            future = tornado.concurrent.Future()
             ex = Exception("oh poo!")
             future.set_exception(ex)
             fetch_mock.return_value = future

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -372,7 +372,7 @@ if has_tornado:
                     },
                     body=json.dumps(payload, default=json_default_handler),
                 )
-                self.http_client.fetch(req, self._response_callback)
+                yield self.http_client.fetch(req, self._response_callback)
                 # store the events that were sent so we can process responses later
                 # it is important that we delete these eventually, or we'll run into memory issues
                 self.batch_data[req] = {"start": start, "events": events}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- when using TornadoTransmission, fetch Future was ignored, which resulted in exceptions not being handled
- this also resulted in the coroutine prematurely releasing the lock
- closes #83 

## Short description of the changes

- yield the fetch call

