### PR TITLE
ci: allow dependabot build to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ workflows:
   build_libhoney:
     jobs:
       - setup_trace:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -178,6 +177,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore:
+              - /pull\/.*/
+              - /dependabot\/.*/
           requires:
             - setup_trace
       - test:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- dependabot and forked PRs don't have access to secrets

## Short description of the changes

- apply our typical filtering setup so that buildevents is a noop on dependabot and forked PR builds

