### PR TITLE
Remove six and mock dependencies.

### DIFF
--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -15,7 +15,7 @@ You can find an example demonstrating usage in example.py'''
 
 import atexit
 import random
-from six.moves.queue import Queue
+from queue import Queue
 
 import libhoney.state as state
 from libhoney.client import Client

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -1,6 +1,5 @@
 import logging
-
-from six.moves import queue
+import queue
 
 from libhoney.event import Event
 from libhoney.builder import Builder

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -1,7 +1,7 @@
 '''Tests for libhoney/client.py'''
 
 import unittest
-import mock
+from unittest import mock
 
 import libhoney
 import libhoney.client as client

--- a/libhoney/test_libhoney.py
+++ b/libhoney/test_libhoney.py
@@ -2,8 +2,8 @@
 
 import datetime
 import json
-import mock
 import unittest
+from unittest import mock
 
 import libhoney
 

--- a/libhoney/test_tornado.py
+++ b/libhoney/test_tornado.py
@@ -1,8 +1,8 @@
 '''Tests for libhoney/transmission.py'''
 import datetime
 import unittest
+from unittest import mock
 
-import mock
 import tornado
 
 import libhoney

--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -8,11 +8,11 @@ import datetime
 import gzip
 import io
 import json
-import mock
+from unittest import mock
 import requests_mock
 import time
 import unittest
-from six.moves import queue
+import queue
 
 
 class TestTransmissionInit(unittest.TestCase):

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -1,8 +1,8 @@
 '''Transmission handles colleting and sending individual events to Honeycomb'''
 from datetime import timedelta
+import queue
+from urllib.parse import urljoin
 
-from six.moves import queue
-from six.moves.urllib.parse import urljoin
 import gzip
 import io
 import json

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,22 +106,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "mock"
-version = "3.0.5"
-description = "Rolling backport of unittest.mock for all Pythons"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-six = "*"
-
-[package.extras]
-build = ["twine", "wheel", "blurb"]
-docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -182,7 +166,7 @@ test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.1
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -242,7 +226,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.5, <4"
-content-hash = "2efa11d8f6c1715c046533be8a5b0130dc4c976b910b75d2627818219318925a"
+content-hash = "58e16b0a2f425ca69df341780ac5a433a0907a0a7b436067af7b5c9dcb993512"
 
 [metadata.files]
 astroid = [
@@ -357,10 +341,6 @@ lazy-object-proxy = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
-mock = [
-    {file = "mock-3.0.5-py2.py3-none-any.whl", hash = "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"},
-    {file = "mock-3.0.5.tar.gz", hash = "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},

--- a/pylint.rc
+++ b/pylint.rc
@@ -537,7 +537,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+redefining-builtins-modules=past.builtins,future.builtins,io,builtins
 
 
 [FORMAT]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,11 @@ repository = "https://github.com/honeycombio/libhoney-py"
 python = ">=3.5, <4"
 requests = "^2.24.0"
 statsd = "^3.3.0"
-six = "^1.15.0"
 
 [tool.poetry.dev-dependencies]
 coverage = [{version = "^5", python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"}]
 pylint = [{version = "^2", python = ">=3.5"}]
 pycodestyle = "^2.6.0"
-mock = {version = "^3.0.5", python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"}
 requests-mock = "^1.8.0"
 tornado = [{version = "^6.0.4", python = ">=3.5"}]
 autopep8 = "^1.5.3"


### PR DESCRIPTION
The six package was useful during Python 2 to 3 migration, but now
libhoney only supports Python 3.

The mock package is already a Python built-in.

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

I'm removing unecessary dependencies, because libhoney only supports Python 3 now.

## Short description of the changes

I removed six and mock.

-

