### PR TITLE
Lazy load import of requests in Transmission class

### DIFF
--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -37,7 +37,7 @@ class TestTransmissionInit(unittest.TestCase):
 
     def test_user_agent_addition(self):
         ''' ensure user_agent_addition is included in the User-Agent header '''
-        with mock.patch('libhoney.transmission.requests.Session') as m_session:
+        with mock.patch('libhoney.transmission.Transmission._get_requests_session') as m_session:
             transmission.Transmission(
                 user_agent_addition='foo/1.0', gzip_enabled=False)
             expected = "libhoney-py/" + libhoney.version.VERSION + " foo/1.0"

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -7,7 +7,6 @@ import gzip
 import io
 import json
 import threading
-import requests
 import statsd
 import sys
 import time
@@ -48,7 +47,7 @@ class Transmission():
         if user_agent_addition:
             user_agent += " " + user_agent_addition
 
-        session = requests.Session()
+        session = self._get_requests_session()
         session.headers.update({"User-Agent": user_agent})
         if self.gzip_enabled:
             session.headers.update({"Content-Encoding": "gzip"})
@@ -67,6 +66,12 @@ class Transmission():
         self.debug = debug
         if debug:
             self._init_logger()
+
+    @staticmethod
+    def _get_requests_session():
+        # lazy load requests only when needed
+        import requests  # pylint: disable=import-outside-toplevel
+        return requests.Session()
 
     def _init_logger(self):
         import logging  # pylint: disable=bad-option-value,import-outside-toplevel


### PR DESCRIPTION
## Which problem is this PR solving?
Reducing libhoney import init time when not directly making use of the Transmission class

## Short description of the changes
When using alternate transmission implementations like FileTransmission there is no need to `import requests`, as this just adds additional initialization time. Initialization time is important especially when running in the context of a Lambda function where cold starts will always need to incur this additional load time. Currently beeline-python uses libhoney Client which imports Transmission and therefore always imports requests.

If this change looks 👍 , could we get a version bump of `libhoney-py` and a corresponding version bump of `beeline-python`?

> init time of beeline running in a Lambda function, largely dominated by requests
<img width="1657" alt="Screen Shot 2022-07-11 at 1 16 44 PM" src="https://user-images.githubusercontent.com/84951447/178350810-0c051f30-3807-45a3-8083-de9dee3f481c.png">

