### PR TITLE
Add Python version to the user agent header.

### DIFF
--- a/libhoney/test_tornado.py
+++ b/libhoney/test_tornado.py
@@ -7,6 +7,7 @@ import tornado
 
 import libhoney
 import libhoney.transmission as transmission
+from platform import python_version
 
 
 class TestTornadoTransmissionInit(unittest.TestCase):
@@ -31,7 +32,7 @@ class TestTornadoTransmissionInit(unittest.TestCase):
         ''' ensure user_agent_addition is included in the User-Agent header '''
         with mock.patch('libhoney.transmission.AsyncHTTPClient') as m_client:
             transmission.TornadoTransmission(user_agent_addition='foo/1.0')
-            expected = "libhoney-py/" + libhoney.version.VERSION + " (tornado/{})".format(tornado.version) + " foo/1.0"
+            expected = "libhoney-py/" + libhoney.version.VERSION + " (tornado/{})".format(tornado.version) + " foo/1.0" + " python/" + python_version()
             m_client.assert_called_once_with(
                 force_instance=True,
                 defaults=dict(user_agent=expected),

--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -3,6 +3,7 @@
 import libhoney
 import libhoney.transmission as transmission
 from libhoney.version import VERSION
+from platform import python_version
 
 import datetime
 import gzip
@@ -41,7 +42,7 @@ class TestTransmissionInit(unittest.TestCase):
         with mock.patch('libhoney.transmission.Transmission._get_requests_session') as m_session:
             transmission.Transmission(
                 user_agent_addition='foo/1.0', gzip_enabled=False)
-            expected = "libhoney-py/" + libhoney.version.VERSION + " foo/1.0"
+            expected = "libhoney-py/" + libhoney.version.VERSION + " foo/1.0" + " python/" + python_version()
             m_session.return_value.headers.update.assert_called_once_with({
                 'User-Agent': expected
             })

--- a/libhoney/test_transmission.py
+++ b/libhoney/test_transmission.py
@@ -40,6 +40,12 @@ class TestTransmissionInit(unittest.TestCase):
     def test_user_agent_addition(self):
         ''' ensure user_agent_addition is included in the User-Agent header '''
         with mock.patch('libhoney.transmission.Transmission._get_requests_session') as m_session:
+            transmission.Transmission(gzip_enabled=False)
+            expected = "libhoney-py/" + libhoney.version.VERSION + " python/" + python_version()
+            m_session.return_value.headers.update.assert_called_once_with({
+                'User-Agent': expected
+            })
+        with mock.patch('libhoney.transmission.Transmission._get_requests_session') as m_session:
             transmission.Transmission(
                 user_agent_addition='foo/1.0', gzip_enabled=False)
             expected = "libhoney-py/" + libhoney.version.VERSION + " foo/1.0" + " python/" + python_version()

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -48,10 +48,12 @@ class Transmission():
         self.gzip_compression_level = gzip_compression_level
         self.gzip_enabled = gzip_enabled
 
-        user_agent = "libhoney-py/" + VERSION
         if user_agent_addition:
-            user_agent += " " + user_agent_addition
-        user_agent += " python/{}".format(python_version())
+            agent_template = "libhoney-py/{} {} python/{}"
+            user_agent = agent_template.format(VERSION, user_agent_addition, python_version())
+        else:
+            agent_template = "libhoney-py/{} python/{}"
+            user_agent = agent_template.format(VERSION, python_version())
 
         session = self._get_requests_session()
         session.headers.update({"User-Agent": user_agent})
@@ -277,10 +279,12 @@ if has_tornado:
             self.max_batch_size = max_batch_size
             self.send_frequency = send_frequency
 
-            user_agent = "libhoney-py/" + VERSION + " (tornado/{})".format(tornado_version)
             if user_agent_addition:
-                user_agent += " " + user_agent_addition
-            user_agent += " python/{}".format(python_version())
+                agent_template = "libhoney-py/{} (tornado/{}) {} python/{}"
+                user_agent = agent_template.format(VERSION, tornado_version, user_agent_addition, python_version())
+            else:
+                agent_template = "libhoney-py/{} (tornado/{}) python/{}"
+                user_agent = agent_template.format(VERSION, tornado_version, python_version())
 
             self.http_client = AsyncHTTPClient(
                 force_instance=True,

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -16,6 +16,7 @@ import time
 import collections
 import concurrent.futures
 
+from platform import python_version
 from libhoney.version import VERSION
 from libhoney.internal import json_default_handler
 
@@ -50,6 +51,7 @@ class Transmission():
         user_agent = "libhoney-py/" + VERSION
         if user_agent_addition:
             user_agent += " " + user_agent_addition
+        user_agent += " python/{}".format(python_version())
 
         session = self._get_requests_session()
         session.headers.update({"User-Agent": user_agent})
@@ -278,6 +280,7 @@ if has_tornado:
             user_agent = "libhoney-py/" + VERSION + " (tornado/{})".format(tornado_version)
             if user_agent_addition:
                 user_agent += " " + user_agent_addition
+            user_agent += " python/{}".format(python_version())
 
             self.http_client = AsyncHTTPClient(
                 force_instance=True,


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #129 

## Short description of the changes

- adds python version to the user agent headers
- user agent template: libhoney/v (transmission/v) beeline/v language/v
- adds a test for the correct string formatting without a useragent_addition (i.e. no extra spaces if no beeline)
