### PR TITLE
Oops! Putting code back where it was: importing requests only when used in Transmission method

### DIFF
--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -71,9 +71,9 @@ class Transmission():
     @staticmethod
     def _get_requests_session():
         # lazy load requests only when needed (for why, see #121)
-        from requests import Session # pylint: disable=import-outside-toplevel
-        from requests.adapters import HTTPAdapter # pylint: disable=import-outside-toplevel
-        from urllib3.util import Retry # pylint: disable=import-outside-toplevel
+        from requests import Session  # pylint: disable=import-outside-toplevel
+        from requests.adapters import HTTPAdapter  # pylint: disable=import-outside-toplevel
+        from urllib3.util import Retry  # pylint: disable=import-outside-toplevel
 
         retry_strategy = Retry(total=1,
                                status_forcelist=[500, 503, 504, 408, 429],  # retry status codes

--- a/libhoney/transmission.py
+++ b/libhoney/transmission.py
@@ -9,9 +9,6 @@ import json
 import threading
 import statsd
 import sys
-from requests import Session
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 import time
 import collections
 import concurrent.futures
@@ -73,6 +70,11 @@ class Transmission():
 
     @staticmethod
     def _get_requests_session():
+        # lazy load requests only when needed (for why, see #121)
+        from requests import Session # pylint: disable=import-outside-toplevel
+        from requests.adapters import HTTPAdapter # pylint: disable=import-outside-toplevel
+        from urllib3.util import Retry # pylint: disable=import-outside-toplevel
+
         retry_strategy = Retry(total=1,
                                status_forcelist=[500, 503, 504, 408, 429],  # retry status codes
                                allowed_methods=["POST"])  # allow 1 retry on post


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
- Related to #105 
- Some of my work in https://github.com/honeycombio/libhoney-py/pull/126 undid https://github.com/honeycombio/libhoney-py/pull/121, putting it back! Apologies. <3 


