### PR TITLE
[release] Prepare 2.3.0 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 2.2.0
+current_version = 2.3.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # libhoney-py Changelog
 ## 2.3.0 2022-09-09
 
-### !!! Breaking Changes !!!
-
-Minimum supported Python version is now 3.7
+⚠️  Minimum supported Python version is now 3.7 ⚠️ 
 ### Maintenance
 
 - Drop Python 3.5, 3.6 Support (#136)| [@emilyashley](https://github.com/emilyashley)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # libhoney-py Changelog
+## 2.3.0 2022-09-09
+
+### !!! Breaking Changes !!!
+
+Minimum supported Python version is now 3.7
+### Maintenance
+
+- Drop Python 3.5, 3.6 Support (#136)| [@emilyashley](https://github.com/emilyashley)
 
 ## 2.2.0 2022-09-02
 

--- a/libhoney/version.py
+++ b/libhoney/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.2.0"  # Update using bump2version
+VERSION = "2.3.0"  # Update using bump2version

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,7 +34,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.6.15.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -298,8 +298,8 @@ bump2version = [
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
+    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libhoney"
-version = "2.2.0" # Update using bump2version
+version = "2.3.0" # Update using bump2version
 description = "Python library for sending data to Honeycomb"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->
### Release:
Drop Support for Python 3.5 and 3.6 in Libhoney (https://github.com/honeycombio/libhoney-py/pull/136)
- Bump Python requirement to version 3.7 or higher, resolve dependencies.
- Follow updated pylint expectations, including using f strings instead of .format()
