### PR TITLE
[Fix] Transitive dependency on specific versions of urllib3 #141

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -282,7 +282,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <4"
-content-hash = "1cd01089742029792e35b829679b5f1ea0449cc0134a94b17d8b5e3c9537d5c1"
+content-hash = "d7a6a183685045d89d684ed7d6a92b5cc244c17bac87c183c842e0565066d4c2"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/honeycombio/libhoney-py"
 python = ">=3.7, <4"
 requests = "^2.24.0"
 statsd = "^3.3.0"
+urllib3 = "^1.26"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.4.4"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [Fix] Transitive dependency on specific versions of urllib3  fixes #141 

We need to specify urllib3 >1.26 as a dependency in order to use the "allowed_methods" on retry. This fell through the cracks because it was a transitive dependency. We should state it explicitly since we rely on this method now! (see: urllib3[changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1260-2020-11-10) )  
