### PR TITLE
maint: update buildevents orb and python convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   python:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
   github:
     docker:
       - image: cibuilds/github:0.13.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
   build_libhoney:
     jobs:
       - setup_trace:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -184,6 +185,7 @@ workflows:
           requires:
             - setup_trace
       - test:
+          context: Honeycomb Secrets for Public Repos
           matrix:
             parameters:
               python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -193,6 +195,7 @@ workflows:
           requires:
             - setup_trace
       - build:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.6
+  buildevents: honeycombio/buildevents@0.9.0
 
 executors:
   python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,6 @@ workflows:
             tags:
               only: /.*/
       - watch:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,12 +169,10 @@ workflows:
   build_libhoney:
     jobs:
       - setup_trace:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -185,7 +183,6 @@ workflows:
           requires:
             - setup_trace
       - test:
-          context: Honeycomb Secrets for Public Repos
           matrix:
             parameters:
               python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -195,7 +192,6 @@ workflows:
           requires:
             - setup_trace
       - build:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ workflows:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - watch:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - setup_trace
       - test:
           matrix:
             parameters:
@@ -172,16 +166,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - watch:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore:
-              - /pull\/.*/
-              - /dependabot\/.*/
-          requires:
-            - setup_trace
       - test:
           matrix:
             parameters:


### PR DESCRIPTION
## Which problem is this PR solving?

- updates internal issue https://github.com/honeycombio/telemetry-team/issues/381

## Short description of the changes

- updates buildevents orb from [0.2.6](https://github.com/honeycombio/buildevents-orb/releases/tag/v0.2.6) to [0.9.0](https://github.com/honeycombio/buildevents-orb/releases/tag/v0.9.0). There are a [ton of changes](https://github.com/honeycombio/buildevents-orb/compare/v0.2.6...v0.9.0), one of which includes a more efficient watch step. Before and after the update shows a drop from **3m 21s** total duration to **1m 24s** total duration!
- not seen here but rather in CircleCI, `BUILDEVENT_APIKEY` and `BUILDEVENT_APIHOST` environment variables were removed to use the Context. Context was updated for Telemetry team `BUILDEVENT_APIKEY`.
- ~...but now context is also removed because we are not currently doing anything with the buildevent telemetry. Leaving the other steps here as an example but the data isn't actually being sent to a dataset.~
- removes watch step from CI
- updates CircleCI convenience image for Python because the image being used was [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

## How to verify that this has the expected result

Circle job should run fine for forks and non-forks alike. No buildevents telemetry should show up in Honeycomb.