### PR TITLE
maint: fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
       - checkout
       - buildevents/berun:
           bename: poetry_install
-          becommand: poetry install --no-root
+          becommand: poetry install --no-root --no-ansi
   run_lint:
     steps:
       - buildevents/berun:


### PR DESCRIPTION
## Which problem is this PR solving?

- latest version of cimg/python images fails the poetry install step with Exit Code 1

## Short description of the changes

- adding --no-ansi flag fixes it (this is what the python orb does)

