### PR TITLE
maint: Update poetry publish to use API token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
       - setup
       - run:
           name: poetry_publish
-          command: poetry publish --build -u honeycomb -p ${PYPI_PASSWORD}
+          command: poetry publish --build -u '__token__' -p ${PYPI_TOKEN}
 
 # required as all of the jobs need to have a tag filter for some reason
 tag_filters: &tag_filters


### PR DESCRIPTION
## Which problem is this PR solving?
Update poetry publish step to use the new API token instead of a username and password.

## Short description of the changes
- Update the publish step to use an API token

