### PR TITLE
feat: support classic-flavored ingest keys

### DIFF
--- a/libhoney/__init__.py
+++ b/libhoney/__init__.py
@@ -18,7 +18,7 @@ import random
 from queue import Queue
 
 from libhoney import state
-from libhoney.client import Client
+from libhoney.client import Client, IsClassicKey
 from libhoney.builder import Builder
 from libhoney.event import Event
 from libhoney.fields import FieldHolder
@@ -196,7 +196,7 @@ atexit.register(close)  # safe because it's a no-op unless init() was called
 
 # export everything
 __all__ = [
-    "Builder", "Event", "Client", "FieldHolder",
+    "Builder", "Event", "Client", "IsClassicKey", "FieldHolder",
     "SendError", "add", "add_dynamic_field",
     "add_field", "close", "init", "responses", "send_now",
 ]

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -10,8 +10,13 @@ from libhoney.transmission import Transmission
 
 def IsClassicKey(key):
     '''Returns true if the API key is a Classic key or a Classic Ingest Key'''
-    return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
-            or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+    if not key:
+        return True
+    if re.match(r'^[a-f0-9]{32}$', key):
+        return True
+    if re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key):
+        return True
+    return False
 
 
 class Client(object):

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -86,7 +86,8 @@ class Client(object):
             self._init_logger()
 
         def IsClassicKey(key):
-            return (key == "" or re.match(r'^[a-f0-9]{32}$', key) or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+            return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
+                    or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
         self.log('initialized honeycomb client: writekey=%s dataset=%s',
                  writekey, dataset)

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -11,7 +11,7 @@ from libhoney.transmission import Transmission
 def IsClassicKey(key):
     '''Returns true if the API key is a Classic key or a Classic Ingest Key'''
     return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
-                or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+            or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
 
 class Client(object):

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -7,6 +7,10 @@ from libhoney.builder import Builder
 from libhoney.fields import FieldHolder
 from libhoney.transmission import Transmission
 
+def IsClassicKey(key):
+    '''Returns true if the API key is a Classic key or a Classic Ingest Key'''
+    return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
+        or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
 class Client(object):
     '''Instantiate a libhoney Client that can prepare and send events to Honeycomb.
@@ -84,10 +88,6 @@ class Client(object):
         self.debug = debug
         if debug:
             self._init_logger()
-
-        def IsClassicKey(key):
-            return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
-                    or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
         self.log('initialized honeycomb client: writekey=%s dataset=%s',
                  writekey, dataset)

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -7,10 +7,12 @@ from libhoney.builder import Builder
 from libhoney.fields import FieldHolder
 from libhoney.transmission import Transmission
 
+
 def IsClassicKey(key):
     '''Returns true if the API key is a Classic key or a Classic Ingest Key'''
     return (key == "" or re.match(r'^[a-f0-9]{32}$', key)
-        or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+                or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+
 
 class Client(object):
     '''Instantiate a libhoney Client that can prepare and send events to Honeycomb.

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import queue
 
 from libhoney.event import Event
@@ -85,7 +86,7 @@ class Client(object):
             self._init_logger()
 
         def IsClassicKey(key):
-            return (len(key) == 32 or key == "")
+            return (len(key) == 32 or key == "" or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
         self.log('initialized honeycomb client: writekey=%s dataset=%s',
                  writekey, dataset)

--- a/libhoney/client.py
+++ b/libhoney/client.py
@@ -86,7 +86,7 @@ class Client(object):
             self._init_logger()
 
         def IsClassicKey(key):
-            return (len(key) == 32 or key == "" or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
+            return (key == "" or re.match(r'^[a-f0-9]{32}$', key) or re.match(r'^hc[a-z]ic_[a-z0-9]{58}$', key))
 
         self.log('initialized honeycomb client: writekey=%s dataset=%s',
                  writekey, dataset)

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -11,6 +11,7 @@ from libhoney.client import IsClassicKey
 def sample_dyn_fn():
     return "dyna", "magic"
 
+
 class TestClient(unittest.TestCase):
     def setUp(self):
         libhoney.close()
@@ -216,8 +217,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(IsClassicKey("c1a551c1111111111111111111111111"), True)
 
     def test_is_classic_with_classic_ingest_key(self):
-         self.assertEqual(IsClassicKey("hcxic_1234567890123456789012345678901234567890123456789012345678"), True)
-         
+        self.assertEqual(IsClassicKey("hcxic_1234567890123456789012345678901234567890123456789012345678"), True)
+
     def test_is_classic_with_configuration_key(self):
         self.assertEqual(IsClassicKey("shinynewenvironmentkey"), False)
 

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -45,6 +45,16 @@ class TestClient(unittest.TestCase):
         self.assertEqual(c.writekey, "")
         self.assertEqual(c.dataset, "")
 
+    def test_init_treats_classic_ingest_key_as_classic_key(self):
+        c = client.Client(writekey="hcxic_1234567890123456789012345678901234567890123456789012345678", dataset="")
+        self.assertEqual(c.writekey, "hcxic_1234567890123456789012345678901234567890123456789012345678")
+        self.assertEqual(c.dataset, "")
+
+    def test_init_treats_ingest_key_as_non_classic_key(self):
+        c = client.Client(writekey="hcxik_1234567890123456789012345678901234567890123456789012345678", dataset="")
+        self.assertEqual(c.writekey, "hcxik_1234567890123456789012345678901234567890123456789012345678")
+        self.assertEqual(c.dataset, "unknown_dataset")
+
     def test_init_sets_default_dataset_with_non_classic_key(self):
         c = client.Client(writekey="shinynewenvironmentkey", dataset="")
         self.assertEqual(c.writekey, "shinynewenvironmentkey")

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -5,11 +5,11 @@ from unittest import mock
 
 import libhoney
 from libhoney import client
+from libhoney.client import IsClassicKey
 
 
 def sample_dyn_fn():
     return "dyna", "magic"
-
 
 class TestClient(unittest.TestCase):
     def setUp(self):
@@ -208,6 +208,21 @@ class TestClient(unittest.TestCase):
         mock_xmit = mock.Mock()
         with client.Client(transmission_impl=mock_xmit) as c:
             self.assertEqual(c.xmit, mock_xmit)
+
+    def test_empty_key(self):
+        self.assertEqual(IsClassicKey(""), True)
+
+    def test_configuration_key(self):
+        self.assertEqual(IsClassicKey("shinynewenvironmentkey"), False)
+
+    def test_ingest_key(self):
+        self.assertEqual(IsClassicKey("hcxik_1234567890123456789012345678901234567890123456789012345678"), False)
+
+    def test_classic_configuration_key(self):
+        self.assertEqual(IsClassicKey("c1a551c1111111111111111111111111"), True)
+
+    def test_classic_ingest_key(self):
+         self.assertEqual(IsClassicKey("hcxic_1234567890123456789012345678901234567890123456789012345678"), True)
 
 
 class TestClientFlush(unittest.TestCase):

--- a/libhoney/test_client.py
+++ b/libhoney/test_client.py
@@ -209,20 +209,20 @@ class TestClient(unittest.TestCase):
         with client.Client(transmission_impl=mock_xmit) as c:
             self.assertEqual(c.xmit, mock_xmit)
 
-    def test_empty_key(self):
+    def test_is_classic_with_empty_key(self):
         self.assertEqual(IsClassicKey(""), True)
 
-    def test_configuration_key(self):
-        self.assertEqual(IsClassicKey("shinynewenvironmentkey"), False)
-
-    def test_ingest_key(self):
-        self.assertEqual(IsClassicKey("hcxik_1234567890123456789012345678901234567890123456789012345678"), False)
-
-    def test_classic_configuration_key(self):
+    def test_is_classic_with_classic_configuration_key(self):
         self.assertEqual(IsClassicKey("c1a551c1111111111111111111111111"), True)
 
-    def test_classic_ingest_key(self):
+    def test_is_classic_with_classic_ingest_key(self):
          self.assertEqual(IsClassicKey("hcxic_1234567890123456789012345678901234567890123456789012345678"), True)
+         
+    def test_is_classic_with_configuration_key(self):
+        self.assertEqual(IsClassicKey("shinynewenvironmentkey"), False)
+
+    def test_is_classic_with_ingest_key(self):
+        self.assertEqual(IsClassicKey("hcxik_1234567890123456789012345678901234567890123456789012345678"), False)
 
 
 class TestClientFlush(unittest.TestCase):


### PR DESCRIPTION
## Which problem is this PR solving?

We've now released Ingest Keys, but in order for them to work with Classic environments properly we need to update the key detection logic.

## Short description of the changes

- updates the Classic API Key detection logic to understand the shape of a Classic Ingest Key
- makes `IsClassicKey` a top level function exported from `libhoney` to be used by the Python beeline